### PR TITLE
Update 6.3 Bubble Sort.ipynb

### DIFF
--- a/6.3 Bubble Sort.ipynb
+++ b/6.3 Bubble Sort.ipynb
@@ -35,13 +35,6 @@
     "        "
    ]
   },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  }
  ],
  "metadata": {
   "kernelspec": {


### PR DESCRIPTION
removing null cell from the bottom