### PR TITLE
Update 6.4 Insertion Sort.ipynb

### DIFF
--- a/6.4 Insertion Sort.ipynb
+++ b/6.4 Insertion Sort.ipynb
@@ -38,13 +38,6 @@
     "    print(ele, end = ' ')"
    ]
   },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  }
  ],
  "metadata": {
   "kernelspec": {


### PR DESCRIPTION
removing null cell from the bottom of the iPython notebook